### PR TITLE
docs: Revise README.md with syntax fixed and practical instruction added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-##qCUDA
+## qCUDA
 qCUDA is based on the virtio framework to provide the para-virtualized driver as “front-end”, 
 and the device module as “back-end” for performing the interaction with API remoting and memory management. 
 In our test environment, qCUDA can achieve above 95% of the bandwidth efficiency for most results by comparing with the native. In addition, by comparing with prior work, qCUDA has more flexibility and interposition that it can execute CUDA-compatible programs in the Linux and Windows VMs, respectively, on QEMU-KVM hypervisor for GPGPU virtualization.
 
-##System Components
+## System Components
 
 The framework of qCUDA has three components, including qCUlibrary, qCUdriver and qCUdevice; the functions of 
 these three components are defined as follows:
@@ -14,22 +14,47 @@ these three components are defined as follows:
 
 * qCUdevice (`qcu-device`) – The virtual device as the back-end was responsible for receiving/sending the qCUcmd through the control channel; it depended on receiving the qCUcmd to active related operations in the host, including to register GPU binary, convert guest physical addresses (GPA) into host virtual addresses (HVA), and handle the CUDA runtime/driver APIs for accessing the GPU.
 
-##Installation
-###Prerequisites
+## Installation
+
+### Prerequisites
+
+#### Host
+
 * CUDA 7.5
 * Ubuntu 14.04.3 LTS (GNU/Linux 3.19.0-25-generic x86_64)
+* export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64"
+* export CUDA_HOME=/usr/local/cuda
+* Install required packages
+  
+	``` sh
+	sudo apt-get install -y  pkg-config bridge-utils uml-utilities zlib1g-dev libglib2.0-dev autoconf
+	automake libtool libsdl1.2-dev libsasl2-dev libcurl4-openssl-dev libsasl2-dev libaio-dev libvde-dev
+	```
+
+#### Guest
+
 * Ubuntu 14.04 image (guest OS)
 * Windows 8 image (guest OS)
+ 
+### How to install
 
-###How to install
-* qcu-device was modified from QEMU 2.4.0, under this forder add the "--enable-cuda option" in the configure: 
-./configure --enable-cuda and then follow the installation steps of QEMU.
+#### Host
 
-* Download qcu-driver and qcu-library in guest OS.
-* Enter qcu-driver and execute the commands:
+* `qcu-device` was modified from QEMU 2.4.0, for further information please refer to [QEMU installation steps](https://en.wikibooks.org/wiki/QEMU/Installing_QEMU)
+
+1. clone this repo.
+2. cd qcu-device
+3. ./configure --enable-cuda --target-list=x86_64-softmmu  && make -j16
+4. sudo mkdir /dev/qcuvf
+5. sudo chmod 777 /dev/qcuvf
+
+#### Guest
+
+1. clone this repo.
+2. Enter `qcu-driver` and execute the commands:
     * make all
     * make i
-* Enter qcu-library and execute the commands:
+3. Enter `qcu-library` and execute the commands:
     * make all
     * make install
 


### PR DESCRIPTION
## Motivation
Original `README.md` contains mistaken header tags which can't be properly rendered. Furthermore, some practical information are absent so that make other contributor hard to participate with.

## Solution
1. Fix all syntax errors.
2. Add practical information.
